### PR TITLE
♻️ refactor(playlist): 변경된 리소스 URL 스키마에 맞게 업데이트

### DIFF
--- a/resources/handlers.py
+++ b/resources/handlers.py
@@ -14,7 +14,7 @@ def register_handlers(mcp):
         ]
       }
 
-  @mcp.resource("create://playlist")
+  @mcp.resource("playlist://create")
   def create_playlist() -> dict:
     """Guidelines for Claude to create a playlist with user-defined song count."""
     return {


### PR DESCRIPTION
- 이전에는 `create://playlist`였던 리소스 URL 스키마를 `playlist://create`로 변경
- 새 스키마는 리소스 명명 규칙과 더 일관성이 있음